### PR TITLE
Make syntax highlighting optional

### DIFF
--- a/docs/_sass/_chameleon_imports.scss
+++ b/docs/_sass/_chameleon_imports.scss
@@ -13,6 +13,7 @@ $font-family-secondary: 'Proxima Nova';
 @include CHAMELEON-base;
 @include CHAMELEON-grid;
 @include CHAMELEON-typography;
+@include CHAMELEON-syntax-highlighting;
 @include CHAMELEON-forms;
 @include CHAMELEON-flex-aligners;
 @include CHAMELEON-alert;

--- a/stylesheets/typography/_typography.scss
+++ b/stylesheets/typography/_typography.scss
@@ -8,5 +8,8 @@
   @include chameleon-typography-base;
   @include chameleon-typography-titles;
   @include chameleon-typography-helpers;
+}
+
+@mixin CHAMELEON-syntax-highlighting {
   @include chameleon-typography-syntax-highlighting;
 }


### PR DESCRIPTION
Syntax highlighting shouldn't be included by default in the typography mixin