### PR TITLE
Add (and extend existing) disabled input style

### DIFF
--- a/stylesheets/forms/_base.scss
+++ b/stylesheets/forms/_base.scss
@@ -36,6 +36,14 @@
     border-width: 1px;
   }
 
+  &:disabled {
+    cursor: not-allowed;
+    opacity: .7;
+    background: #d4d4d4;
+    border: 1px solid darken(#d4d4d4, 10%);
+    color: #444444;
+  }
+
   &.input--light {
     color: #fff;
   }

--- a/stylesheets/forms/_buttons.scss
+++ b/stylesheets/forms/_buttons.scss
@@ -175,7 +175,8 @@
       }
     }
 
-    &--disabled {
+    &--disabled,
+    &:disabled {
       cursor: not-allowed;
       opacity: .7;
       background: #d4d4d4;


### PR DESCRIPTION
1. Disabled buttons required a class _and_ attribute. This has been changed so that `btn--disabled` styles now apply to `btn`'s with a `disabled` attribute.
2. Disabled inputs now get the same general treatment as disabled buttons when the `disabled` attribute is present, to make clear to users the field can not be interacted with _intentionally_.